### PR TITLE
Updates shyp to rely on pangyp for iojs builds.

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "node-shyp",
   "version": "v0.4.0",
   "description": "",
+  "repository": "https://github.com/tcr/node-shyp",
   "main": "shyp.js",
   "bin": {
     "node-shyp": "./shyp.js",
@@ -14,11 +15,12 @@
   "license": "BSD-2-Clause",
   "dependencies": {
     "async": "~0.2.9",
-    "mkdirp": "~0.3.5",
-    "rimraf": "~2.2.5",
-    "dnode": "~1.2.0",
     "colors": "~0.6.2",
-    "semver": "~2.2.1",
-    "request": "~2.34.0"
+    "dnode": "~1.2.0",
+    "mkdirp": "~0.3.5",
+    "pangyp": "git+https://github.com/tcr/pangyp",
+    "request": "~2.34.0",
+    "rimraf": "~2.2.5",
+    "semver": "~2.2.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-shyp",
-  "version": "v0.4.0",
+  "version": "v0.5.0",
   "description": "",
   "repository": "https://github.com/tcr/node-shyp",
   "main": "shyp.js",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
   "dependencies": {
     "async": "~0.2.9",
     "colors": "~0.6.2",
-    "dnode": "~1.2.0",
     "mkdirp": "~0.3.5",
     "pangyp": "git+https://github.com/tcr/pangyp",
     "request": "~2.34.0",


### PR DESCRIPTION
node-gyp, though it lists versions of iojs, hasn't been able to download and build them. This is due to
1. node-gyp configure not erroring properly in shyp
2. builds still generating .node files without its source code
3. node-gyp not yet having iojs support.

While the latter point is being rectified soon, this release switches to pangyp (specifically, one that can target node and iojs).
